### PR TITLE
Enhancements: Introducing Config toc attribute and supporting application/vnd.ms-opentype font export type

### DIFF
--- a/lib/bupe/config.ex
+++ b/lib/bupe/config.ex
@@ -84,7 +84,8 @@ defmodule BUPE.Config do
           cover: boolean,
           logo: String.t(),
           audio: [map()],
-          fonts: [map()]
+          fonts: [map()],
+          toc: [map()]
         }
 
   @enforce_keys [:title, :pages]
@@ -114,5 +115,6 @@ defmodule BUPE.Config do
             cover: true,
             logo: nil,
             audio: [],
-            fonts: []
+            fonts: [],
+            toc: []
 end

--- a/lib/bupe/parser.ex
+++ b/lib/bupe/parser.ex
@@ -137,7 +137,8 @@ defmodule BUPE.Parser do
          pages: find_manifest(xml, "application/xhtml+xml"),
          audio: find_manifest(xml, ["audio/mpeg", "audio/mp4"]),
          fonts:
-           find_manifest(xml, ["application/font-sfnt", "application/font-woff", "font/woff2"])
+           find_manifest(xml, ["application/font-sfnt", "application/font-woff", "font/woff2"]),
+         toc: find_manifest(xml, "application/x-dtbncx+xml")
      }}
   end
 

--- a/lib/bupe/parser.ex
+++ b/lib/bupe/parser.ex
@@ -137,7 +137,7 @@ defmodule BUPE.Parser do
          pages: find_manifest(xml, "application/xhtml+xml"),
          audio: find_manifest(xml, ["audio/mpeg", "audio/mp4"]),
          fonts:
-           find_manifest(xml, ["application/font-sfnt", "application/font-woff", "font/woff2"]),
+           find_manifest(xml, ["application/font-sfnt", "application/font-woff", "font/woff2", "application/vnd.ms-opentype"]),
          toc: find_manifest(xml, "application/x-dtbncx+xml")
      }}
   end


### PR DESCRIPTION
* Added a toc attribute to Config:
  Added a new attribute named toc to the BUPE.Config  module. This attribute is used to reference the table of contents (TOC) content within a file.
* Include application/vnd.ms-opentype as a font export type:
 Expanded the range of supported font export types by including application/vnd.ms-opentype as a valid type for exporting fonts.

These changes aim to enhance the functionality of the project by introducing a new attribute for handling table of contents content and broadening the support for font export types.