### PR TITLE
fix epub3 overview doc link

### DIFF
--- a/lib/bupe.ex
+++ b/lib/bupe.ex
@@ -170,7 +170,7 @@ defmodule BUPE do
         version: "3.0"
       }
 
-  [EPUB]: http://www.idpf.org/epub3/latest/overview
+  [EPUB]: https://idpf.org/epub/301/spec/epub-overview.html
   """
   defdelegate parse(epub_file), to: BUPE.Parser, as: :run
 end


### PR DESCRIPTION
the old epub3 overview link seems to be dead.
this pr replaces to dead link to an equivalent link from idpf.org for epub3 overview