### PR TITLE
Fix toc parsing

### DIFF
--- a/test/bupe_test.exs
+++ b/test/bupe_test.exs
@@ -39,17 +39,45 @@ defmodule BUPETest do
       assert result.title == "Minimal EPUB 2.0"
       assert result.identifier == "NOID"
 
-      [toc] = result.toc
-      assert toc.id == "ncx"
-      assert toc.href == "toc.ncx"
-      assert toc.media_type == "application/x-dtbncx+xml"
-
       assert result.nav == [%{idref: "content_001"}]
       [page] = result.pages
       assert page.href == "content_001.xhtml"
       assert page.id == "content_001"
       assert page.media_type == "application/xhtml+xml"
       assert page.content =~ "<title>Minimal EPUB</title>"
+    end
+
+    @tag :tmp_dir
+    test "parse toc of epub version 3.0", %{tmp_dir: tmp_dir} do
+      config = config()
+
+      output = Path.join(tmp_dir, "sample.epub")
+      {:ok, {_name, epub}} = BUPE.build(config, output, [:memory])
+
+      epub_info = BUPE.parse(epub)
+
+      [toc] = epub_info.toc
+      assert toc.id == "nav"
+      assert toc.href == "nav.xhtml"
+      assert toc.media_type == "application/xhtml+xml"
+      assert String.length(toc.content) > 0
+    end
+
+    @tag :tmp_dir
+    test "parse toc of epub version 2.0", %{tmp_dir: tmp_dir} do
+      config = config()
+      config = Map.put(config, :version, "2.0")
+
+      output = Path.join(tmp_dir, "sample.epub")
+      {:ok, {_name, epub}} = BUPE.build(config, output, [:memory])
+
+      epub_info = BUPE.parse(epub)
+
+      [toc] = epub_info.toc
+      assert toc.id == "ncx"
+      assert toc.href == "toc.ncx"
+      assert toc.media_type == "application/x-dtbncx+xml"
+      assert String.length(toc.content) > 0
     end
   end
 

--- a/test/bupe_test.exs
+++ b/test/bupe_test.exs
@@ -39,12 +39,12 @@ defmodule BUPETest do
       assert result.title == "Minimal EPUB 2.0"
       assert result.identifier == "NOID"
 
-      assert result.toc == [
-               %{id: "ncx", href: "toc.ncx", "media-type": "application/x-dtbncx+xml"}
-             ]
+      [toc] = result.toc
+      assert toc.id == "ncx"
+      assert toc.href == "toc.ncx"
+      assert toc.media_type == "application/x-dtbncx+xml"
 
       assert result.nav == [%{idref: "content_001"}]
-
       [page] = result.pages
       assert page.href == "content_001.xhtml"
       assert page.id == "content_001"


### PR DESCRIPTION
I’m building an Elixir EPUB reader and plan to use bupe’s `Parser` module and then I ran into the issue described in https://github.com/milmazz/bupe/issues/91.
This PR is my approach to extract the table of contents (TOC) from an EPUB.

### Design
1) Where to store TOC data in `BUPE.Config`:
   - Decision: The options were to put toc data in `nav` field, or `toc` field, or create a new field to put it in. In the end i decided to store TOC data in the existing `toc` key of `BUPE.Config`.
   - Rationale and tradeoffs:
     - The `nav` key represents information from the package/spine section of `content.opf`, which is not the TOC. It is the [default reading order](https://www.w3.org/TR/epub-33/#sec-spine-plane), which is useful on its own, so we should not overwrite it with TOC data.
     - The previous parser (before this PR) did not populate the `toc` key with much useful information for either EPUB 2 or EPUB 3.
     - Using a single `toc` key for both EPUB 2 and EPUB 3 provides a uniform place to access TOC data and simplifies future processing.

2) What to store in TOC items:
   - Decision: extract and store the raw XHTML/HTML content from the TOC/navigation files without further parsing. The raw content is stored in the `content` key of `BUPE.item`.
   - Rationale: elsewhere in `BUPE.item`, the `content` key holds raw assets without additional processing (e.g., page `content` is raw HTML; styles `content` is raw CSS). This keeps TOC handling consistent with existing data. Thus this PR does not implement the structured/parsed TOC representation discussed in
https://github.com/milmazz/bupe/issues/91#issuecomment-2887783010. I think that feature can be added in a subsequent change.

### Implementation
#### EPUB 2.0 TOC extraction
According to the [official spec](https://idpf.org/epub/20/spec/OPF_2.0_final_spec.html#Section2.4):
> The spine element must include the `toc` attribute, whose value is the id attribute value of the required NCX document declared in the manifest (see Section 2.4.1.).

Steps:
1. Parse the `spine` element’s `toc` attribute.
2. Find the corresponding item in the manifest with that `id`.
3. Use the item’s `href` to locate the navigation document.

#### EPUB 3.0 TOC extraction
According to the [official spec](https://www.w3.org/TR/epub-33/#sec-nav-prop):
> The `nav` property indicates that the described publication resource constitutes the EPUB navigation document of the EPUB publication. EPUB creators MUST declare exactly one item as the EPUB navigation document using the `nav` property.

Steps:
1. Find the manifest item whose `properties` attribute contains the `nav` token.
2. Use that item’s `href` to locate the navigation document.

Please let me know if you have any questions about these design decisions or the implementation.
