### PR TITLE
fix: erlang version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.19.0-rc.0-otp-28
-erlang 28
+erlang 28.0.4


### PR DESCRIPTION
as seen in the screenshot, it looks like `28` is not a valid version when i tried to installed it.

i changed the version to `28.0.4`, which is the latest as of now

<img width="1267" height="678" alt="image" src="https://github.com/user-attachments/assets/dd87cb96-8c3f-4bdf-a7d7-3aff32353e42" />
